### PR TITLE
Codify stream order

### DIFF
--- a/tap_mavenlink/__init__.py
+++ b/tap_mavenlink/__init__.py
@@ -3,6 +3,7 @@
 import singer
 
 import tap_framework
+from tap_framework.state import save_state
 
 from tap_mavenlink.client import MavenlinkClient
 from tap_mavenlink.streams import AVAILABLE_STREAMS
@@ -11,7 +12,34 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class MavenlinkRunner(tap_framework.Runner):
-    pass
+    # Sync the streams in the order specified in the
+    # streams/__init__.py list of AVAILABLE_STREAMS
+    def do_sync(self):
+        LOGGER.info("Starting sync.")
+
+        streams = self.get_streams_to_replicate()
+        stream_map = {s.NAME: s for s in streams}
+
+        for available_stream in AVAILABLE_STREAMS:
+            if available_stream.NAME not in stream_map:
+                continue
+
+            stream = stream_map[available_stream.NAME]
+            try:
+                stream.state = self.state
+                stream.sync()
+                self.state = stream.state
+            except OSError as e:
+                LOGGER.error(str(e))
+                exit(e.errno)
+
+            except Exception as e:
+                LOGGER.error(str(e))
+                LOGGER.error('Failed to sync endpoint {}, moving on!'
+                             .format(stream.TABLE))
+                raise e
+
+        save_state(self.state)
 
 
 @singer.utils.handle_top_exception(LOGGER)

--- a/tap_mavenlink/streams/__init__.py
+++ b/tap_mavenlink/streams/__init__.py
@@ -39,24 +39,5 @@ AVAILABLE_STREAMS = [
     WorkspacesStream,
 ]
 
-__all__ = [
-    'AccountMembershipsStream',
-    'AssignmentsStream',
-    'CustomFieldsStream',
-    'WorkspaceCustomFieldValuesStream',
 
-    'EstimatesStream',
-    'EstimatesScenariosStream',
-    'EstimatesResourcesStream',
-
-    'ExpenseCategoriesStream',
-    'ExpensesStream',
-    'InvoicesStream',
-    'PostsStream',
-    'StoriesStream',
-    'TimeEntriesStream',
-    'UsersStream',
-    'WorkspaceAllocationsStream',
-    'WorkspaceGroupsStream',
-    'WorkspacesStream',
-]
+__all__ = [s.NAME for s in AVAILABLE_STREAMS]

--- a/tap_mavenlink/streams/account_memberships.py
+++ b/tap_mavenlink/streams/account_memberships.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class AccountMembershipsStream(BaseStream):
+    NAME = 'AccountMembershipsStream'
     API_METHOD = 'GET'
     TABLE = 'account_memberships'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/assignments.py
+++ b/tap_mavenlink/streams/assignments.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class AssignmentsStream(BaseStream):
+    NAME = 'AssignmentsStream'
     API_METHOD = 'GET'
     TABLE = 'assignments'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/custom_fields.py
+++ b/tap_mavenlink/streams/custom_fields.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class CustomFieldsStream(BaseStream):
+    NAME = 'CustomFieldsStream'
     API_METHOD = 'GET'
     TABLE = 'custom_fields'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/estimates.py
+++ b/tap_mavenlink/streams/estimates.py
@@ -6,6 +6,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class EstimatesStream(BaseStream):
+    NAME = 'EstimatesStream'
     API_METHOD = 'GET'
     TABLE = 'estimates'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/estimates_resources.py
+++ b/tap_mavenlink/streams/estimates_resources.py
@@ -7,6 +7,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class EstimatesResourcesStream(ResourceSubStream):
+    NAME = 'EstimatesResourcesStream'
     API_METHOD = 'GET'
     TABLE = 'estimate_scenario_resources'
     PARENT = 'estimate_scenarios'

--- a/tap_mavenlink/streams/estimates_scenarios.py
+++ b/tap_mavenlink/streams/estimates_scenarios.py
@@ -6,6 +6,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class EstimatesScenariosStream(BaseStream):
+    NAME = 'EstimatesScenariosStream'
     API_METHOD = 'GET'
     TABLE = 'estimate_scenarios'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/expense_categories.py
+++ b/tap_mavenlink/streams/expense_categories.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class ExpenseCategoriesStream(BaseStream):
+    NAME = 'ExpenseCategoriesStream'
     API_METHOD = 'GET'
     TABLE = 'expense_categories'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/expenses.py
+++ b/tap_mavenlink/streams/expenses.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class ExpensesStream(BaseStream):
+    NAME = 'ExpensesStream'
     API_METHOD = 'GET'
     TABLE = 'expenses'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/invoices.py
+++ b/tap_mavenlink/streams/invoices.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class InvoicesStream(BaseStream):
+    NAME = 'InvoicesStream'
     API_METHOD = 'GET'
     TABLE = 'invoices'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/posts.py
+++ b/tap_mavenlink/streams/posts.py
@@ -6,6 +6,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class PostsStream(BaseStream):
+    NAME = 'PostsStream'
     API_METHOD = 'GET'
     TABLE = 'posts'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/stories.py
+++ b/tap_mavenlink/streams/stories.py
@@ -6,6 +6,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class StoriesStream(BaseStream):
+    NAME = 'StoriesStream'
     API_METHOD = 'GET'
     TABLE = 'stories'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/time_entries.py
+++ b/tap_mavenlink/streams/time_entries.py
@@ -6,6 +6,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class TimeEntriesStream(BaseStream):
+    NAME = 'TimeEntriesStream'
     API_METHOD = 'GET'
     TABLE = 'time_entries'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/users.py
+++ b/tap_mavenlink/streams/users.py
@@ -6,6 +6,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class UsersStream(BaseStream):
+    NAME = 'UsersStream'
     API_METHOD = 'GET'
     TABLE = 'users'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/workspace_allocations.py
+++ b/tap_mavenlink/streams/workspace_allocations.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class WorkspaceAllocationsStream(BaseStream):
+    NAME = 'WorkspaceAllocationsStream'
     API_METHOD = 'GET'
     TABLE = 'workspace_allocations'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/workspace_custom_field_values.py
+++ b/tap_mavenlink/streams/workspace_custom_field_values.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class WorkspaceCustomFieldValuesStream(BaseStream):
+    NAME = 'WorkspaceCustomFieldValuesStream'
     API_METHOD = 'GET'
     TABLE = 'workspace_custom_field_values'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/workspace_groups.py
+++ b/tap_mavenlink/streams/workspace_groups.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class WorkspaceGroupsStream(BaseStream):
+    NAME = 'WorkspaceGroupsStream'
     API_METHOD = 'GET'
     TABLE = 'workspace_groups'
     KEY_PROPERTIES = ['id']

--- a/tap_mavenlink/streams/workspaces.py
+++ b/tap_mavenlink/streams/workspaces.py
@@ -5,6 +5,7 @@ LOGGER = singer.get_logger()  # noqa
 
 
 class WorkspacesStream(BaseStream):
+    NAME = 'WorkspacesStream'
     API_METHOD = 'GET'
     TABLE = 'workspaces'
     KEY_PROPERTIES = ['id']


### PR DESCRIPTION
Sync streams in the order specified in `tap_mavenlink/streams/__init__.py` so `EstimatesScenarios` syncs before `EstimatesResources`. This is important because the tap uses the `EstimatesScenarios` ids to sync `EstimatesResources`.